### PR TITLE
createEndpoint wrapper function with strong type inferencing

### DIFF
--- a/example/src/auth/index.ts
+++ b/example/src/auth/index.ts
@@ -2,8 +2,8 @@ import jwt from "jsonwebtoken"
 import passport from "passport"
 import { ExtractJwt, Strategy as JWTStrategy } from "passport-jwt"
 import { User } from "../database/models/User"
-import { ErrorStatus } from "../../src/core/types"
-import { createErrorMessage } from "../../src/core/errors"
+import { ErrorStatus } from "../../../src/core/types"
+import { createErrorMessage } from "../../../src/core/errors"
 
 const SECRET_KEY = "test"
 

--- a/example/src/modules/root/rootRouter.ts
+++ b/example/src/modules/root/rootRouter.ts
@@ -4,22 +4,9 @@ import { createEndpoint } from "../../../../src/core"
 
 export const rootRouter = express.Router()
 
-/**
- * This is a good example of where, you can throw in inline generic types
- * With comments formatting, we could annotate this endpoint as:
- * @endpoint ApiRoot GET /api
- * This assigns this endpoint a name of "APIRoot", a GET request, with path /api
- * Whatever the name is, it'll take the generic arguments (IGetRequest & { message: string })
- * and assign those with the types:
- * type IApiRootRequest = IGetRequest
- * type IApiRootResponse = { message: string }
- * The problem with this is that there's no guarantee that the actual endpoint & http method actually
- * matches up with the comment
- */
-
+// here, the response type is inferred as numebr | "hello"
 rootRouter.get(
   "/",
-  // here, the response type is inferred as numebr | "hello"
   createEndpoint(async () => {
     if (Math.random() < 0.5) {
       return Math.random()
@@ -27,4 +14,10 @@ rootRouter.get(
     return "hello"
   })
 )
+
+rootRouter.get(
+  "/date",
+  createEndpoint(async () => ({ date: new Date() }))
+)
+
 rootRouter.use("/users", userRouter)

--- a/example/src/modules/root/rootRouter.ts
+++ b/example/src/modules/root/rootRouter.ts
@@ -1,9 +1,15 @@
 import express from "express"
 import { userRouter } from "../user/userRouter"
 import { createEndpoint } from "../../../../src/core"
-import { IGetRequest } from "../../../../src/core/types"
+import { Middleware } from "../../../../src/core/types"
 
 export const rootRouter = express.Router()
+
+const sampleMiddleware: Middleware<MiddlewareCounter, MiddlewareCounter> = endpoint => middleware => options => {
+  return endpoint({
+    count: (middleware?.count ?? 0) + 1
+  })(options)
+}
 
 /**
  * This is a good example of where, you can throw in inline generic types
@@ -19,8 +25,18 @@ export const rootRouter = express.Router()
  */
 rootRouter.get(
   "/",
-  createEndpoint<IGetRequest, { message: string }>(async () => ({
-    message: "Hello World"
-  })).init()
+  createEndpoint(
+    sampleMiddleware(
+      sampleMiddleware(middleware => async () => {
+        return {
+          middlewares: middleware?.count ?? -1
+        }
+      })
+    )
+  )
 )
 rootRouter.use("/users", userRouter)
+
+type MiddlewareCounter = {
+  count: number
+}

--- a/example/src/modules/root/rootRouter.ts
+++ b/example/src/modules/root/rootRouter.ts
@@ -1,15 +1,8 @@
 import express from "express"
 import { userRouter } from "../user/userRouter"
 import { createEndpoint } from "../../../../src/core"
-import { Middleware } from "../../../../src/core/types"
 
 export const rootRouter = express.Router()
-
-const sampleMiddleware: Middleware<MiddlewareCounter, MiddlewareCounter> = endpoint => middleware => options => {
-  return endpoint({
-    count: (middleware?.count ?? 0) + 1
-  })(options)
-}
 
 /**
  * This is a good example of where, you can throw in inline generic types
@@ -23,20 +16,15 @@ const sampleMiddleware: Middleware<MiddlewareCounter, MiddlewareCounter> = endpo
  * The problem with this is that there's no guarantee that the actual endpoint & http method actually
  * matches up with the comment
  */
+
 rootRouter.get(
   "/",
-  createEndpoint(
-    sampleMiddleware(
-      sampleMiddleware(middleware => async () => {
-        return {
-          middlewares: middleware?.count ?? -1
-        }
-      })
-    )
-  )
+  // here, the response type is inferred as numebr | "hello"
+  createEndpoint(async () => {
+    if (Math.random() < 0.5) {
+      return Math.random()
+    }
+    return "hello"
+  })
 )
 rootRouter.use("/users", userRouter)
-
-type MiddlewareCounter = {
-  count: number
-}

--- a/example/src/modules/user/userController.ts
+++ b/example/src/modules/user/userController.ts
@@ -5,11 +5,7 @@ import { comparePassword } from "../../utils/password"
 import { IUserLoginEndpoint, IUserRegisterRequest, IUserRegisterResponse } from "./userTypes"
 import { createEndpoint } from "../../../../src/core"
 
-type MiddlewareCounter = {
-  count: number
-}
-
-export const register = createEndpoint<IUserRegisterRequest, IUserRegisterResponse>(() => async ({ req, error }) => {
+export const register = createEndpoint<IUserRegisterRequest, IUserRegisterResponse>(async ({ req, error }) => {
   if (req.body.username.length < 4 || req.body.password.length < 8) {
     return error.badRequest(new Error("Username or password too short"))
   }
@@ -32,7 +28,7 @@ export const register = createEndpoint<IUserRegisterRequest, IUserRegisterRespon
   }
 })
 
-export const login: IUserLoginEndpoint = () => async ({ req, error }) => {
+export const login: IUserLoginEndpoint = async ({ req, error }) => {
   const { username, password } = req.body
   const user = await User.findOne({
     where: { username }

--- a/example/src/modules/user/userController.ts
+++ b/example/src/modules/user/userController.ts
@@ -2,10 +2,9 @@ import { nanoid } from "nanoid"
 import { generateToken, TokenType } from "../../auth"
 import { createUserModel, User } from "../../database/models/User"
 import { comparePassword } from "../../utils/password"
-import { IUserLoginEndpoint, IUserRegisterRequest, IUserRegisterResponse } from "./userTypes"
-import { createEndpoint } from "../../../../src/core"
+import { IUserLoginEndpoint, IUserRegisterEndpoint } from "./userTypes"
 
-export const register = createEndpoint<IUserRegisterRequest, IUserRegisterResponse>(async ({ req, error }) => {
+export const register: IUserRegisterEndpoint = async ({ req, error }) => {
   if (req.body.username.length < 4 || req.body.password.length < 8) {
     return error.badRequest(new Error("Username or password too short"))
   }
@@ -26,7 +25,7 @@ export const register = createEndpoint<IUserRegisterRequest, IUserRegisterRespon
     access_token: generateToken(id, TokenType.ACCESS_TOKEN),
     user: createUserModel(user)
   }
-})
+}
 
 export const login: IUserLoginEndpoint = async ({ req, error }) => {
   const { username, password } = req.body

--- a/example/src/modules/user/userRouter.ts
+++ b/example/src/modules/user/userRouter.ts
@@ -4,5 +4,5 @@ import * as controller from "./userController"
 
 export const userRouter = express.Router()
 
-userRouter.post(`/register`, controller.register)
+userRouter.post(`/register`, createEndpoint(controller.register))
 userRouter.post(`/login`, createEndpoint(controller.login))

--- a/example/src/modules/user/userRouter.ts
+++ b/example/src/modules/user/userRouter.ts
@@ -1,17 +1,8 @@
 import express from "express"
-import { createEndpoint, validateBody } from "../../../../src/core"
+import { createEndpoint } from "../../../../src/core"
 import * as controller from "./userController"
 
 export const userRouter = express.Router()
 
-userRouter.post(
-  `/register`,
-  createEndpoint(controller.register).validate([
-    validateBody(["username", "password", "secret"]),
-    req => [(req.body.username?.length || 0) > 4, "Username length is too short"]
-  ])
-)
-
-userRouter.post(`/login`, createEndpoint(controller.login).validate([validateBody(["username", "password"])]))
-
-userRouter.get("/authorize", createEndpoint(controller.authorize).init())
+userRouter.post(`/register`, controller.register)
+userRouter.post(`/login`, createEndpoint(controller.login))

--- a/example/src/modules/user/userTypes.ts
+++ b/example/src/modules/user/userTypes.ts
@@ -1,4 +1,4 @@
-import { IUserModel, User } from "../../database/models/User"
+import { IUserModel } from "../../database/models/User"
 import { IExpressEndpointHandler, IGetRequest, IPostRequest } from "../../../../src/core/types"
 
 export type IUserRegisterRequest = IPostRequest<
@@ -39,4 +39,4 @@ export type IUserAuthorizeResponse = {
   user: IUserModel
 }
 
-export type IUserAuthorizeEndpoint = IExpressEndpointHandler<IUserAuthorizeRequest, IUserAuthorizeResponse, User>
+export type IUserAuthorizeEndpoint = IExpressEndpointHandler<IUserAuthorizeRequest, IUserAuthorizeResponse>

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -8,8 +8,7 @@ import {
   ErrorStatus,
   IExpressResponse,
   IResponse,
-  IExpressRequest,
-  IExpressEndpointHandlerOptions
+  IExpressRequest
 } from "./types"
 import { createErrorStatus, prefixErrorMessage } from "./errors"
 
@@ -103,10 +102,3 @@ export const verifyObject = (body: object, keys: (string | number | symbol)[]) =
 }
 
 export const buildProto = <T>(data: Partial<T>) => data as T
-
-export const handleErrors = (...cases: [boolean, IErrorStatus][]): IErrorStatus | undefined => {
-  const results = cases.filter(testCase => testCase[0])
-  if (results.length) {
-    return results[0][1]
-  }
-}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -8,7 +8,8 @@ import {
   ErrorStatus,
   IExpressResponse,
   IResponse,
-  IExpressRequest
+  IExpressRequest,
+  IExpressEndpointHandlerOptions
 } from "./types"
 import { createErrorStatus, prefixErrorMessage } from "./errors"
 
@@ -38,40 +39,15 @@ export const sendErrorResponse = <T, S extends IRequest>(
     .end()
 }
 
-export const createEndpoint = <Req extends IRequest = IRequest, Res extends {} = {}, T extends {} = {}>(
-  endpoint: IExpressEndpointHandler<Req, Res, T>
-) => {
-  return async (req: IExpressRequest<Req>, res: IExpressResponse<IResponse<Res>>) => {
-    try {
-      const result = await endpoint()({
-        req,
-        res,
-        error: errorStatus,
-        // middleware values don't matter in the response
-        fromMiddleware: {}
-      })
-      const asError = result as IErrorStatus
-      if (typeof result === "object" && asError.isError) {
-        return sendErrorResponse(req, res, asError.type, asError.error)
-      }
-      return sendSuccessResponse(res, result as Res)
-    } catch (err) {
-      return sendErrorResponse(req, res, ErrorStatus.INTERNAL_ERROR, err)
-    }
-  }
-}
-
-export const createSimpleEndpoint = <Req extends IRequest = IRequest, Res extends {} = {}>(
-  endpoint: ReturnType<IExpressEndpointHandler<Req, Res>>
+export const createEndpoint = <Req extends IRequest = IRequest, Res = {}>(
+  endpoint: IExpressEndpointHandler<Req, Res>
 ) => {
   return async (req: IExpressRequest<Req>, res: IExpressResponse<IResponse<Res>>) => {
     try {
       const result = await endpoint({
         req,
         res,
-        error: errorStatus,
-        // middleware values don't matter in the response
-        fromMiddleware: {}
+        error: errorStatus
       })
       const asError = result as IErrorStatus
       if (typeof result === "object" && asError.isError) {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -45,24 +45,15 @@ export interface IDeleteRequest<Params extends Record<string, string>, Body exte
   type: HttpMethod.DELETE
 }
 
-export type IExpressEndpointHandlerOptions<
-  Req extends IRequest = IRequest,
-  Res = {},
-  AdditionalOptions extends {} = {}
-> = {
+export type IExpressEndpointHandlerOptions<Req extends IRequest = IRequest, Res = {}> = {
   req: IExpressRequest<Req>
   res: IExpressResponse<IResponse<Res>>
   error: IErrorStatusMethods
-  fromMiddleware: Partial<AdditionalOptions>
 }
 
-export type IExpressEndpointHandler<Req extends IRequest = IRequest, Res = {}, AdditionalOptions = {}> = (
-  middleware?: AdditionalOptions
-) => (options: IExpressEndpointHandlerOptions<Req, Res>) => Promise<Res | IErrorStatus>
-
-export type Middleware<T extends {}, S extends {} = {}> = <Req extends IRequest, Res extends {}>(
-  endpoint: IExpressEndpointHandler<Req, Res, T & S>
-) => (middleware?: S) => ReturnType<IExpressEndpointHandler<Req, Res, T & S>>
+export type IExpressEndpointHandler<Req extends IRequest = IRequest, Res = {}> = (
+  options: IExpressEndpointHandlerOptions<Req, Res>
+) => Promise<Res | IErrorStatus>
 
 export enum ErrorStatus {
   BAD_REQUEST = 400,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -45,13 +45,24 @@ export interface IDeleteRequest<Params extends Record<string, string>, Body exte
   type: HttpMethod.DELETE
 }
 
-export type IExpressEndpointHandler<Req extends IRequest = IRequest, Res = {}, T = unknown> = (options: {
+export type IExpressEndpointHandlerOptions<
+  Req extends IRequest = IRequest,
+  Res = {},
+  AdditionalOptions extends {} = {}
+> = {
   req: IExpressRequest<Req>
   res: IExpressResponse<IResponse<Res>>
   error: IErrorStatusMethods
-  user: T | null
-  token: string | null
-}) => Promise<Res | IErrorStatus>
+  fromMiddleware: Partial<AdditionalOptions>
+}
+
+export type IExpressEndpointHandler<Req extends IRequest = IRequest, Res = {}, AdditionalOptions = {}> = (
+  middleware?: AdditionalOptions
+) => (options: IExpressEndpointHandlerOptions<Req, Res>) => Promise<Res | IErrorStatus>
+
+export type Middleware<T extends {}, S extends {} = {}> = <Req extends IRequest, Res extends {}>(
+  endpoint: IExpressEndpointHandler<Req, Res, T & S>
+) => (middleware?: S) => ReturnType<IExpressEndpointHandler<Req, Res, T & S>>
 
 export enum ErrorStatus {
   BAD_REQUEST = 400,
@@ -68,11 +79,11 @@ export type IErrorStatus = {
 }
 
 export type IErrorStatusMethods = {
-  forbidden: (err?: Error) => IErrorStatus
-  unauthorized: (err?: Error) => IErrorStatus
-  badRequest: (err?: Error) => IErrorStatus
-  notFound: (err?: Error) => IErrorStatus
-  internalError: (err?: Error) => IErrorStatus
+  forbidden: (err?: Error) => Promise<IErrorStatus>
+  unauthorized: (err?: Error) => Promise<IErrorStatus>
+  badRequest: (err?: Error) => Promise<IErrorStatus>
+  notFound: (err?: Error) => Promise<IErrorStatus>
+  internalError: (err?: Error) => Promise<IErrorStatus>
 }
 
 export type IRequestValidation<Req extends IRequest<{}, {}, {}>> = (


### PR DESCRIPTION
`createEndpoint` is always able to strongly infer the type of the response. Assumes the request type to be without params, body, or query unless specified. 

The only thing is how do we name the types?